### PR TITLE
Add arm64 to build action, fix branch names

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,22 +3,26 @@ name: Docker Image CI
 on:
   push:
     branches: 
-     - master
+     - main
     tags: 
      - '*'
      
   pull_request:
     branches: 
-      - master
+      - main
       
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - 
+    -
         name: Checkout
         uses: actions/checkout@v2
     
+    -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
     -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -49,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: src/
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hey there,

this PR fixes #19 as it adds an arm64 build to the pipeline. After this is run on the main repo, both amd64 and arm64 images should be available.

It also fixes the branch names, I assume the master branch was renamed to main at one point.